### PR TITLE
add semaphores for QueueSubmit

### DIFF
--- a/dali/graphics/vulkan/vulkan-fence.cpp
+++ b/dali/graphics/vulkan/vulkan-fence.cpp
@@ -53,6 +53,18 @@ struct Fence::Impl
     return vk::Result::eErrorInitializationFailed;
   }
 
+  vk::Result Initialise(bool isSignaled)
+  {
+    vk::FenceCreateInfo info;
+    if (isSignaled)
+      info.setFlags(vk::FenceCreateFlagBits::eSignaled);
+
+    mFence = VkAssert( mGraphics.GetDevice().createFence( info, mGraphics.GetAllocator() ) );
+    if( mFence )
+      return vk::Result::eSuccess;
+    return vk::Result::eErrorInitializationFailed;
+  }
+
   /**
    *
    * @param timeout
@@ -107,6 +119,19 @@ Handle<Fence> Fence::New( Graphics& graphics )
 {
   auto retval = Handle<Fence>( new Fence(graphics) );
   if( vk::Result::eSuccess == retval->mImpl->Initialise() )
+  {
+    return retval;
+  }
+  return Handle<Fence>();
+}
+
+//Init value is signaled.
+Handle<Fence> Fence::New( Graphics& graphics, bool isSignaled )
+{
+  auto retval = Handle<Fence>( new Fence(graphics) );
+
+  //
+  if( vk::Result::eSuccess == retval->mImpl->Initialise(isSignaled) )
   {
     return retval;
   }

--- a/dali/graphics/vulkan/vulkan-fence.h
+++ b/dali/graphics/vulkan/vulkan-fence.h
@@ -34,6 +34,7 @@ class Fence : public VkManaged
 public:
 
   static Handle<Fence> New( Graphics& graphics );
+  static Handle<Fence> New( Graphics& graphics, bool isSignaled );
 
   Fence( Fence&& ) = default;
   ~Fence();

--- a/dali/graphics/vulkan/vulkan-framebuffer.cpp
+++ b/dali/graphics/vulkan/vulkan-framebuffer.cpp
@@ -59,7 +59,7 @@ struct Framebuffer::Impl
 
       vk::AttachmentDescription attDesc{};
       attDesc.setSamples( vk::SampleCountFlagBits::e1 )
-        .setInitialLayout( vk::ImageLayout::eColorAttachmentOptimal )
+        .setInitialLayout( vk::ImageLayout::eUndefined )
         .setFormat( colorAttachment->GetImage()->GetVkFormat() )
         .setStencilStoreOp( vk::AttachmentStoreOp::eDontCare )
         .setStencilLoadOp( vk::AttachmentLoadOp::eDontCare )
@@ -88,7 +88,7 @@ struct Framebuffer::Impl
 
       vk::AttachmentDescription attDesc{};
       attDesc.setSamples( vk::SampleCountFlagBits::e1 )
-             .setInitialLayout( vk::ImageLayout::eDepthStencilAttachmentOptimal )
+             .setInitialLayout( vk::ImageLayout::eUndefined )
              .setFormat( mDepthStencilImageViewAttachment->GetImage()->GetVkFormat() )
              .setStencilStoreOp( vk::AttachmentStoreOp::eDontCare )
              .setStencilLoadOp( vk::AttachmentLoadOp::eDontCare )

--- a/dali/graphics/vulkan/vulkan-graphics.cpp
+++ b/dali/graphics/vulkan/vulkan-graphics.cpp
@@ -209,7 +209,7 @@ void Graphics::CreateInstance( const std::vector<const char*>& extensions, const
   info.setEnabledExtensionCount(U32(extensions.size()))
       .setPpEnabledExtensionNames(extensions.data())
       .setEnabledLayerCount(U32(validationLayers.size()))
-      .setEnabledLayerCount(0)
+      // .setEnabledLayerCount(0)
       .setPpEnabledLayerNames(validationLayers.data());
 
   mInstance = VkAssert(vk::createInstance(info, *mAllocator));
@@ -299,7 +299,7 @@ SwapchainRef Graphics::CreateSwapchainForSurface( SurfaceRef surface )
 {
   auto swapchain = Swapchain::New( *this,
                                    GetGraphicsQueue(0u),
-                                   surface, 2, 0 );
+                                   surface, 3, 0 );
 
   // store swapchain in the correct pair
   for( auto&& val : mSurfaceFBIDMap )

--- a/dali/graphics/vulkan/vulkan-queue.h
+++ b/dali/graphics/vulkan/vulkan-queue.h
@@ -53,8 +53,13 @@ public:
   std::unique_ptr< Submission > Submit(const std::vector< CommandBufferRef >& commandBuffers,
                                        Handle<Fence>                                 fence);
 
+  std::unique_ptr< Submission > Submit(const std::vector< CommandBufferRef >& commandBuffers, vk::Semaphore& waitSemaphore, 
+                                            vk::Semaphore& signalSemaphore, Handle<Fence> fence);
+
   /** Helper function to submit single command buffer */
   std::unique_ptr< Submission > Submit(CommandBufferRef commandBuffer, Handle<Fence> fence);
+
+  std::unique_ptr< Submission > Submit(CommandBufferRef commandBuffer, vk::Semaphore& waitSemaphore, vk::Semaphore& signalSemaphore, Handle<Fence> fence);
 
   void WaitIdle() const;
 


### PR DESCRIPTION
I can't push gerrit. So I created a Pull Request.
Dali rendered 2~3 frames. (only the numbur of swapchain images).
So I added semaphores. (It is just for test)

After semaphores were applied, Validation layer printed below at vkQueueSubmit.

> DS(ERROR): object: 0xffffffffaadb4cec type: 6 location: 2722 msgCode: 6: Cannot submit cmd buffer using image (0xffffffffaac92360) [sub-resource: aspectMask 0x1 array layer 0, mip level 0], 
with layout VK_IMAGE_LAYOUT_PRESENT_SRC_KHR when first use is VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL.

So I modified initial layout in vulkan-framebuffer.cpp.
```
-        .setInitialLayout( vk::ImageLayout::eColorAttachmentOptimal )
+        .setInitialLayout( vk::ImageLayout::eUndefined )
```

If this patch is applied, Dali renders normally.

