### PR TITLE
Fix fastcov.py copy error

### DIFF
--- a/build/scripts/dali_env
+++ b/build/scripts/dali_env
@@ -231,7 +231,7 @@ sub create_env
 
     copy($0, "$install_path/bin/dali_env");
     chmod(0755, "$install_path/bin/dali_env");
-    my $fastcov_src = "$root_path/../dali-core/build/scripts/fastcov.py";
+    my $fastcov_src = "$exec_path/fastcov.py";
     copy($fastcov_src, "$install_path/bin/fastcov.py") or die "Failed to copy $fastcov_src to $install_path/bin/fastcov.py: $!";
     chmod(0755, "$install_path/bin/fastcov.py");
 }


### PR DESCRIPTION
1. Fix fastcov.py copy error

```
Checking for required system packages (may require sudo password)
Failed to copy /home/user/dali-env/../dali-core/build/scripts/fastcov.py to /home/user/dali-env/opt/bin/fastcov.py: No such file or directory at /home/user/Workspace/A2UI/dali-core/build/scripts/dali_env line 235.
```